### PR TITLE
Remove the redundant tox `skip_missing_interpreters` setting

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,6 @@ envlist =
     py{3.13, 3.12, 3.11, 3.10, 3.9}
     coverage-report
     mypy
-skip_missing_interpreters = True
 labels =
     update=update
 


### PR DESCRIPTION

This PR removes the redundant tox `skip_missing_interpreters` setting in `tox.ini`.
This codifies the recently-discovered fact that it's true by default.


<sub>This PR was generated using [turbolift](https://github.com/Skyscanner/turbolift).</sub>