### PR TITLE
Updates

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -41,19 +41,19 @@ jobs:
               - "3.10"
               - "3.11"
               - "3.12"
-            cpython-beta: "3.13"
+              - "3.13"
 
           # Test lowest and highest versions on Mac.
           - runner: "macos-latest"
             cpythons:
               - "3.9"
-              - "3.12"
+              - "3.13"
 
           # Test lowest and highest versions on Windows.
           - runner: "windows-latest"
             cpythons:
               - "3.9"
-              - "3.12"
+              - "3.13"
 
     uses: "kurtmckee/github-workflows/.github/workflows/tox.yaml@2f156c58bf4ceebc623014b407f5711899e41235" # v1.0
     with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,11 @@ packages = [
     { include = "pelican", from = "src" }
 ]
 readme = "README.rst"
+keywords = ["pelican", "plugin"]
+classifiers = [
+    "Framework :: Pelican :: Plugins",
+    "Development Status :: 5 - Production/Stable",
+]
 
 [tool.poetry.dependencies]
 python = ">=3.9"
@@ -73,6 +78,4 @@ ignore_missing_imports = true
 addopts = "--color=yes"
 filterwarnings = [
     "error",
-    # dateutil throws a DeprecationWarning on Python 3.12.
-    "ignore:datetime.datetime.utcfromtimestamp:DeprecationWarning:dateutil",
 ]


### PR DESCRIPTION
* Make Python 3.13 non-beta in CI
* Remove a now-unnecessary pytest warning filter
* Add PyPI keywords and trove classifiers